### PR TITLE
Apple macro enabled

### DIFF
--- a/byteswap.h
+++ b/byteswap.h
@@ -1,0 +1,4 @@
+#include <libkern/OSByteOrder.h>
+#define bswap_16(x) OSSwapInt16(x)
+#define bswap_32(x) OSSwapInt32(x)
+#define bswap_64(x) OSSwapInt64(x)

--- a/j2534.c
+++ b/j2534.c
@@ -13,7 +13,7 @@
 #include <stdlib.h>
 #include <libusb.h>
 #include <string.h>
-#include <byteswap.h>
+#include "byteswap.h"
 #include "j2534.h"
 
 const char* DllVersion = "2.0.3";
@@ -294,7 +294,6 @@ long PassThruOpen(const void* pName, unsigned long* pDeviceID)
 	r = get_endpoints(devs, cnt, VENDOR_ID, PRODUCT_ID, endpoint);
 	libusb_free_device_list(devs, 1);
 
-	libusb_set_debug(con->ctx, 3);
 	con->dev_handle = libusb_open_device_with_vid_pid(con->ctx, VENDOR_ID,
 			PRODUCT_ID);
 	if (con->dev_handle == NULL )

--- a/j2534.c
+++ b/j2534.c
@@ -13,7 +13,9 @@
 #include <stdlib.h>
 #include <libusb.h>
 #include <string.h>
+#ifdef __APPLE__
 #include "byteswap.h"
+#endif
 #include "j2534.h"
 
 const char* DllVersion = "2.0.3";
@@ -294,7 +296,10 @@ long PassThruOpen(const void* pName, unsigned long* pDeviceID)
 	r = get_endpoints(devs, cnt, VENDOR_ID, PRODUCT_ID, endpoint);
 	libusb_free_device_list(devs, 1);
 
-	con->dev_handle = libusb_open_device_with_vid_pid(con->ctx, VENDOR_ID,
+      #ifndef __APPLE__
+	libusb_set_debug(con->ctx, 3);
+      #endif
+        con->dev_handle = libusb_open_device_with_vid_pid(con->ctx, VENDOR_ID,
 			PRODUCT_ID);
 	if (con->dev_handle == NULL )
 	{

--- a/makefile
+++ b/makefile
@@ -3,14 +3,13 @@ INSTALL_PREFIX=/usr/local
 INSTALL_LIBDIR=$(INSTALL_PREFIX)/lib
 
 j2534: j2534.o
-	gcc -g -shared j2534.o $(CFLAGS) -o j2534.so
-	ldd j2534.so
+	gcc -g -shared j2534.o $(CFLAGS) -o j2534.dylib
 j2534.o: j2534.c
 	gcc -g -fPIC -c j2534.c $(CFLAGS)
 tags: j2534.c
 	ctags --c-kinds=+cl * /usr/include/libusb-1.0/libusb.h
 clean:
-	rm -f j2534.o j2534.so
+	rm -f j2534.o j2534.dylib
 install: j2534
 	mkdir -p $(INSTALL_LIBDIR)
 	mkdir -p $(INSTALL_PREFIX)/include/

--- a/makefile
+++ b/makefile
@@ -1,18 +1,23 @@
 CFLAGS=`pkg-config --cflags --libs libusb-1.0`
 INSTALL_PREFIX=/usr/local
 INSTALL_LIBDIR=$(INSTALL_PREFIX)/lib
+ifdef __APPLE__
+LIBRARY=j2534.dylib
+else
+LIBRARY=j2534.so
+endif
 
 j2534: j2534.o
-	gcc -g -shared j2534.o $(CFLAGS) -o j2534.dylib
+	gcc -g -shared j2534.o $(CFLAGS) -o $(LIBRARY)
 j2534.o: j2534.c
 	gcc -g -fPIC -c j2534.c $(CFLAGS)
 tags: j2534.c
 	ctags --c-kinds=+cl * /usr/include/libusb-1.0/libusb.h
 clean:
-	rm -f j2534.o j2534.dylib
+	rm -f j2534.o $(LIBRARY)
 install: j2534
 	mkdir -p $(INSTALL_LIBDIR)
 	mkdir -p $(INSTALL_PREFIX)/include/
 	cp j2534.h $(INSTALL_PREFIX)/include/
 	cp j2534.pc /usr/lib/pkgconfig/
-	cp j2534.so $(INSTALL_LIBDIR)/j2534.so
+	cp $(LIBRARY) $(INSTALL_LIBDIR)/$(LIBRARY)


### PR DESCRIPTION
Using macros eases portability for the future, aiming to avoid code conflicts. 